### PR TITLE
[REFACTOR] 소셜 로그인 redirect_uri 리팩토링

### DIFF
--- a/src/views/LoginPage.vue
+++ b/src/views/LoginPage.vue
@@ -15,8 +15,14 @@ export default {
   name: "loginPage",
   data() {
     return {
-      GoogleLogin: process.env.VUE_APP_API_URL + `/oauth2/authorize/google`,
-      KaKaoLogin: process.env.VUE_APP_API_URL + `/oauth2/authorize/kakao`,
+      GoogleLogin:
+        process.env.VUE_APP_API_URL +
+        `/oauth2/authorize/google` +
+        process.env.VUE_APP_REDIRECT_URL,
+      KaKaoLogin:
+        process.env.VUE_APP_API_URL +
+        `/oauth2/authorize/kakao` +
+        process.env.VUE_APP_REDIRECT_URL,
     };
   },
 };


### PR DESCRIPTION
### 📌 개발 개요
- resolve #35 
  <br>

### 💻  작업 및 변경 사항
- 기존 소셜 로그인 완료가 되었을 때 로그인한 유저 권한이 guest면 `/join` 컴포넌트로 redirect가 되고 로그인한 유저 권한이 user 일땐 `/` 로 redirect가 됩니다.
- 이렇게 되는 이유는 백엔드에서 권한에 맞게 리다이렉트를 하드코딩 해서 보내줬었습니다.
- 배포시와 로컬에서 테스트할시 redirect되는 uri가 다르므로 백엔드에서는 고정해놓고
- 프론트에서 동적으로 처리할 수 있도록 구현하였습니다.
- .env파일에 양식은 `?redirect_uri={redirect할 uri}` 로 설정하시면 될 것 같습니다.
  <br>

### ✅ Point
- .env 파일에 환경변수 설정할 때 유의할 부분은
- Vue CLI에서는 변수 이름에 VUE_APP_ 접두사를 붙여야 사용가능 하다고 합니다.  
- 저같은 경우는 `VUE_APP_REDIRECT_URI` 라는 변수를 사용하였습니다.  
  <br>