### PR TITLE
[BUG] 작품 검색 버그 발생 및 리팩토링

### DIFF
--- a/src/components/layout/MainHeader.vue
+++ b/src/components/layout/MainHeader.vue
@@ -26,9 +26,9 @@
     <b-navbar-nav class="right">
       <b-nav-form class="mt-1" style="margin-right: 10px" id="searchForm">
         <input
-          placeholder="작품을 검색하세요!"
+          placeholder="작품 제목을 검색하세요!"
           type="text"
-          v-model="searchKeyword"
+          v-model="searchTitle"
         />
         <b-button size="sm" class="my-2 my-sm-0" @click="toSearch()"
           >검색</b-button
@@ -82,7 +82,7 @@ export default {
     return {
       message: "MainHeader",
       accessToken: this.$store.getters.getAccessToken,
-      searchKeyword: "",
+      searchTitle: "",
     };
   },
   methods: {
@@ -144,7 +144,7 @@ export default {
     },
     toSearch() {
       location.href =
-        "/search?novelId=null&genre=&author=&title=" + this.searchKeyword;
+        "/search?novelId=null&genre=&author=&title=" + this.searchTitle;
     },
   },
   mounted() {


### PR DESCRIPTION
### 📌 개발 개요
- resolve #37 
  <br>

### 💻  작업 및 변경 사항
- 헤더에서 작품 검색 후 검색 페이지에서 스크롤 할 때 검색어가 적용되지 않던 부분은 `this.$route.query.title`로 데이터를 전달 받았지만 변수에 할당하지 않은 채로 그 변수를 사용하였기에 검색어가 적용되지 않았습니다.
- `MainHeader.vue` 파일의 placeholder 및 검색어 변수 수정 -> 검색 시 제목만 검색하도록 바꾸었기 때문에 작품 제목에 관련된 것으로 수정
- `NovelSearchPage.vue`
  - 작품 조회 스크롤 시에는 스크롤이 잘되는데 작품 검색시 스크롤이 되었다 안되었다 하는 이유는
  - 작품조회시 사용하는 api요청은 간단한 쿼리문 이지만, 검색시 사용하는 쿼리문은 단순조회보다 복잡하기에 시간이 걸릴경우 `infiniteHandler`가 먼저 실행될 가능성이 있다고 합니다. 그래서 그때는 데이터가 없는데 스크롤을 하려고 하다보니 스크롤이 되지 않은 버그가 발생했습니다.
  - 해결은 데이터가 받아와 졌는지 체크 후에 스크롤을 하도록 구현하였습니다.
  <br>
