### PR TITLE
[FEAT] API 연결 추가 , 신청페이지 이동 구현

### DIFF
--- a/src/components/layout/MainHeader.vue
+++ b/src/components/layout/MainHeader.vue
@@ -21,7 +21,7 @@
         >커뮤니티</b-nav-item
       >
       <b-nav-item style="font-size: 27px" @click="toFanclub()"
-        >팬클럽</b-nav-item
+        >메신저</b-nav-item
       >
     </b-navbar-nav>
 

--- a/src/views/FanclubPage.vue
+++ b/src/views/FanclubPage.vue
@@ -50,7 +50,7 @@
               <img :src="author.imageUrl" height="200px" />
               {{ author.nickname }}
               <br />
-              <b-button variant="primary" @click="joinRoom(author.rid)">
+              <b-button variant="primary" @click="joinRoom(author.userId)">
                 채팅방 참여
               </b-button>
             </slide>
@@ -77,7 +77,7 @@
               <img :src="room.imageUrl" height="200px" />
               {{ room.nickname }}
               <br />
-              <b-button variant="primary" @click="joinRoom(room.rid)">
+              <b-button variant="primary" @click="joinRoom(room.userId)">
                 채팅방 참여
               </b-button>
             </slide>
@@ -163,15 +163,14 @@ export default {
     }
   },
   methods: {
-    // rid를 받아오는 값이 없어 아직 미 구현
-    async joinRoom(rid) {
+    async joinRoom(uid) {
       try {
         const option = {
           headers: {
             Authorization: "Bearer " + this.$getAccessToken(),
           },
         };
-        await axios.post("/api/v1/chat/" + rid, option);
+        await axios.post(`/api/v1/chat/${uid}`, {}, option);
       } catch (err) {
         console.log(err);
       }

--- a/src/views/FanclubPage.vue
+++ b/src/views/FanclubPage.vue
@@ -3,7 +3,7 @@
     <header>
       <div class="row justify-content-end">
         <div class="col">
-          <h1>팬클럽</h1>
+          <h1>메신저</h1>
         </div>
         <div class="col-auto">
           <b-form-input placeholder="작가명" type="text" v-model="author" />
@@ -29,80 +29,205 @@
         </div>
       </div>
     </header>
-    <div>
-      <carousel-3d
-        :disable3d="true"
-        :space="365"
-        :clickable="false"
-        :controls-visible="true"
-        class="carousel-container"
-      >
-        <slide :index="0">
-          <img src="/favicon.ico" width="100px" height="200px" />
-          <br />
-          작가 1
-          <br />
-          <b-button variant="primary">팔로우</b-button>
-        </slide>
-        <slide :index="1">
-          <img src="/favicon.ico" width="100px" height="200px" />
-          <br />
-          작가 2
-          <br />
-          <b-button variant="primary">팔로우</b-button>
-        </slide>
-        <slide :index="2">
-          <img src="/favicon.ico" width="100px" height="200px" />
-          <br />
-          작가 3
-          <br />
-          <b-button variant="primary">팔로우</b-button>
-        </slide>
-        <slide :index="3">
-          <img src="/favicon.ico" width="100px" height="200px" />
-          <br />
-          작가 4
-          <br />
-          <b-button variant="primary">팔로우</b-button>
-        </slide>
-        <slide :index="4">
-          <img src="/favicon.ico" width="100px" height="200px" />
-          <br />
-          작가 5
-          <br />
-          <b-button variant="primary">팔로우</b-button>
-        </slide>
-      </carousel-3d>
+    <br />
+    <div v-if="!searchedAuthor">
+      <div>
+        <div v-if="authorList.length > 0">
+          <h3>최신 작가</h3>
+          <carousel-3d
+            :disable3d="true"
+            :space="365"
+            :clickable="false"
+            :controls-visible="true"
+            class="carousel-container"
+          >
+            <slide
+              v-for="(author, index) in authorList"
+              :key="index"
+              :index="index"
+              style="width: 250px; height: 300px"
+            >
+              <img :src="author.imageUrl" height="200px" />
+              {{ author.nickname }}
+              <br />
+              <b-button variant="primary" @click="joinRoom(author.rid)">
+                채팅방 참여
+              </b-button>
+            </slide>
+          </carousel-3d>
+        </div>
+      </div>
+      <br />
+      <div>
+        <div v-if="roomList.length > 0">
+          <h3>인기 채팅방</h3>
+          <carousel-3d
+            :disable3d="true"
+            :space="365"
+            :clickable="false"
+            :controls-visible="true"
+            class="carousel-container"
+          >
+            <slide
+              v-for="(room, index) in roomList"
+              :key="index"
+              :index="index"
+              style="width: 250px; height: 300px"
+            >
+              <img :src="room.imageUrl" height="200px" />
+              {{ room.nickname }}
+              <br />
+              <b-button variant="primary" @click="joinRoom(room.rid)">
+                채팅방 참여
+              </b-button>
+            </slide>
+          </carousel-3d>
+        </div>
+      </div>
     </div>
-    <div class="author-list-box">
-      <b-row>
-        <b-col class="mb-3" cols="12" sm="6" md="4" lg="3">
-          <b-card class="b-card" align="center">
-            <b-card-img src="/favicon.ico" class="card-image"></b-card-img>
-            <b-card-title class="card-title">작가 1</b-card-title>
-            <b-button variant="primary" class="card-btn">팔로우</b-button>
-          </b-card>
-        </b-col>
-      </b-row>
+    <div v-if="searchedAuthor">
+      <div class="author-list-box" ref="allAuthorList">
+        <b-row>
+          <b-col
+            v-for="(author, index) in authors"
+            :key="index"
+            class="mb-3"
+            cols="12"
+            sm="6"
+            md="4"
+            lg="3"
+          >
+            <b-card @click="detailNovelList(author.userId)">
+              <b-card-img :src="author.imageUrl" class="card-image">
+              </b-card-img>
+              <b-card-title>{{ author.nickname }}</b-card-title>
+              <b-card-text>
+                <b-button variant="primary" @click="joinRoom(author.rid)">
+                  채팅방 참여
+                </b-button>
+              </b-card-text>
+              <b-card-text>{{ author.userId }}</b-card-text>
+            </b-card>
+          </b-col>
+        </b-row>
+      </div>
+      <infinite-loading
+        @infinite="infiniteHandler"
+        spinner="waveDots"
+      ></infinite-loading>
     </div>
   </div>
 </template>
 
 <script>
+import axios from "axios";
 import { Carousel3d, Slide } from "vue-carousel-3d";
+import InfiniteLoading from "vue-infinite-loading";
 
 export default {
   data() {
     return {
+      author: "",
+      authorList: [],
+      roomList: [],
       authors: [],
+      userId: 0,
+      searchedAuthor: false,
     };
   },
-  created() {
-    this.authors = this.$route.params.data;
+  async created() {
+    try {
+      const authorRes = await axios.get("/api/v1/user/author");
+      this.authorList = authorRes.data;
+
+      const roomRes = await axios.get("/api/v1/user/chatroom");
+      this.roomList = roomRes.data;
+    } catch (err) {
+      console.log(err);
+    }
   },
   components: {
     Carousel3d,
     Slide,
+    InfiniteLoading,
+  },
+  async mounted() {
+    try {
+      const res = await axios.get(
+        `/api/v1/user/author?nickname=${this.author}`
+      );
+      this.authors = res.data;
+      this.userId = this.authors[this.authors.length - 1].userId;
+    } catch (err) {
+      console.log(err);
+    }
+  },
+  methods: {
+    // rid를 받아오는 값이 없어 아직 미 구현
+    async joinRoom(rid) {
+      try {
+        const option = {
+          headers: {
+            Authorization: "Bearer " + this.$getAccessToken(),
+          },
+        };
+        await axios.post("/api/v1/chat/" + rid, option);
+      } catch (err) {
+        console.log(err);
+      }
+    },
+    async infiniteHandler($state) {
+      if (!this.authors.length) {
+        // 데이터가 없는 경우 초기 데이터를 가져옵니다.
+        try {
+          const res = await axios.get(
+            `/api/v1/user/author?nickname=${this.author}`
+          );
+          this.authors = res.data;
+          this.userId = this.authors[this.authors.length - 1].userId;
+          $state.loaded();
+        } catch (err) {
+          console.log(err);
+        }
+        return;
+      }
+      try {
+        console.log(this.userId);
+        const res = await axios.get(
+          `/api/v1/user/author?enrollId=` +
+            this.userId +
+            `&nickname=` +
+            this.author
+        );
+        console.log("length :" + res.data.length);
+        if (res.data.length) {
+          this.authors = this.authors.concat(res.data);
+          this.userId = this.authors[this.authors.length - 1].userId;
+          $state.loaded(); //데이터 로딩
+          if (this.userId / res.data.length == 0) {
+            $state.complete(); //데이터가 없으면 로딩 끝
+          }
+        } else {
+          $state.complete();
+        }
+      } catch (err) {
+        console.log(err);
+        alert("에러");
+        location.href = "/";
+      }
+    },
+    async search() {
+      try {
+        const res = await axios.get(
+          `/api/v1/user/author?nickname=${this.author}`
+        );
+        this.authors = [];
+        this.authors = res.data;
+        this.searchedAuthor = true;
+      } catch (err) {
+        console.log(err);
+      }
+    },
   },
 };
 </script>
@@ -119,7 +244,6 @@ export default {
 }
 
 img {
-  margin-top: 20px;
   border-radius: 50%;
   width: 150px;
   height: 150px;
@@ -130,5 +254,9 @@ img {
   margin-top: 2%;
   margin-left: 5%;
   margin-right: 5%;
+}
+
+#allProductList {
+  height: 400px; /* 스크롤이 표시될 최대 높이값 */
 }
 </style>

--- a/src/views/MainPage.vue
+++ b/src/views/MainPage.vue
@@ -68,7 +68,7 @@
           <img :src="author.imageUrl" height="200px" class="userimg" />
           {{ author.nickname }}
           <br />
-          <b-button variant="primary" @click="joinRoom(author.rid)">
+          <b-button variant="primary" @click="joinRoom(author.userId)">
             채팅방 참여
           </b-button>
         </slide>
@@ -180,15 +180,14 @@ export default {
     shuffle(arr) {
       arr.sort(() => Math.random() - 0.5);
     },
-    // rid를 받아오는 값이 없어 아직 미 구현
-    async joinRoom(rid) {
+    async joinRoom(uid) {
       try {
         const option = {
           headers: {
             Authorization: "Bearer " + this.$getAccessToken(),
           },
         };
-        await axios.post("/api/v1/chat/" + rid, option);
+        await axios.post(`/api/v1/chat/${uid}`, {}, option);
       } catch (err) {
         console.log(err);
       }

--- a/src/views/MainPage.vue
+++ b/src/views/MainPage.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="products">
     <div v-if="products.length > 0">
-      <h3>주간 인기 작품</h3>
+      <h3>최신 작품</h3>
       <carousel-3d
         :pagination="true"
         :controls-visible="true"
@@ -125,7 +125,9 @@ export default {
   name: "MainPage",
   async created() {
     try {
-      const productsRes = await axios.get("/api/v1/novel");
+      const productsRes = await axios.get(
+        "/api/v1/novel?sort=CREATED_DATE_DESC"
+      );
       const temp = productsRes.data;
       this.shuffle(temp);
       this.products = temp;

--- a/src/views/MainPage.vue
+++ b/src/views/MainPage.vue
@@ -130,7 +130,7 @@ export default {
       this.shuffle(temp);
       this.products = temp;
 
-      const novelsRes = await axios.get("/api/v1/novel?novelId=3994");
+      const novelsRes = await axios.get("/api/v1/novel?sort=NOVEL_LIKE_DESC");
       this.novelList = novelsRes.data;
 
       const authorRes = await axios.get("/api/v1/user/author");

--- a/src/views/MainPage.vue
+++ b/src/views/MainPage.vue
@@ -50,35 +50,67 @@
       </carousel-3d>
     </div>
     <br />
-    <div>
-      <h3>신인 작가</h3>
+    <div v-if="authorList.length > 0">
+      <h3>최신 작가</h3>
       <carousel-3d
         :disable3d="true"
         :space="365"
         :clickable="false"
         :controls-visible="true"
+        class="carousel-container"
       >
-        <slide :index="0"> Slide 1 Content </slide>
-        <slide :index="1"> Slide 1 Content </slide>
-        <slide :index="2"> Slide 1 Content </slide>
-        <slide :index="3"> Slide 1 Content </slide>
-        <slide :index="4"> Slide 1 Content </slide>
+        <slide
+          v-for="(author, index) in authorList"
+          :key="index"
+          :index="index"
+          style="width: 250px; height: 350px"
+        >
+          <img :src="author.imageUrl" height="200px" class="userimg" />
+          {{ author.nickname }}
+          <br />
+          <b-button variant="primary" @click="joinRoom(author.rid)">
+            채팅방 참여
+          </b-button>
+        </slide>
       </carousel-3d>
     </div>
     <br />
-    <div>
-      <h3>주간 인기 리뷰</h3>
+    <div v-if="reviewList.length > 0">
+      <h3>인기 리뷰</h3>
       <carousel-3d
         :disable3d="true"
         :space="365"
         :clickable="false"
         :controls-visible="true"
+        class="carousel-container"
       >
-        <slide :index="0"> Slide 1 Content </slide>
-        <slide :index="1"> Slide 1 Content </slide>
-        <slide :index="2"> Slide 1 Content </slide>
-        <slide :index="3"> Slide 1 Content </slide>
-        <slide :index="4"> Slide 1 Content </slide>
+        <slide
+          v-for="(review, index) in reviewList"
+          :key="index"
+          :index="index"
+          style="width: 250px; height: 300px"
+        >
+          <img
+            :src="review.imageUrl"
+            height="200px"
+            @click="detailNovelList(review)"
+            class="userimg"
+          />
+          <!-- review를 받아오는 데이터에서 novelId 값이 없어 아직 미 구현 -->
+          <span @click="detailNovelList(review)" style="text-align: center">
+            {{ review.nickname }}
+            <br />
+            {{ review.reviewGrade }}
+            <br />
+            {{
+              review.reviewContent.length > 45
+                ? review.reviewContent.substring(0, 44) + "..."
+                : review.reviewContent
+            }}
+            <br />
+            {{ review.title + ", " + review.author }}
+          </span>
+        </slide>
       </carousel-3d>
     </div>
     <br />
@@ -100,6 +132,12 @@ export default {
 
       const novelsRes = await axios.get("/api/v1/novel?novelId=3994");
       this.novelList = novelsRes.data;
+
+      const authorRes = await axios.get("/api/v1/user/author");
+      this.authorList = authorRes.data;
+
+      const reviewRes = await axios.get("/api/v1/review?sort=REVIEW_LIKE_DESC");
+      this.reviewList = reviewRes.data.content;
     } catch (err) {
       console.log(err);
     }
@@ -108,6 +146,8 @@ export default {
     return {
       novelList: [],
       products: [],
+      authorList: [],
+      reviewList: [],
       paginationCustom: {
         style: {
           backgroundColor: "#fff",
@@ -140,6 +180,19 @@ export default {
     shuffle(arr) {
       arr.sort(() => Math.random() - 0.5);
     },
+    // rid를 받아오는 값이 없어 아직 미 구현
+    async joinRoom(rid) {
+      try {
+        const option = {
+          headers: {
+            Authorization: "Bearer " + this.$getAccessToken(),
+          },
+        };
+        await axios.post("/api/v1/chat/" + rid, option);
+      } catch (err) {
+        console.log(err);
+      }
+    },
   },
 };
 </script>
@@ -149,5 +202,20 @@ export default {
 }
 h3 {
   font-family: "Hanna";
+}
+
+.carousel-container .carousel-3d-slide .userimg {
+  margin-top: 10px;
+  border-radius: 50%;
+  width: 100px;
+  height: 100px;
+  object-fit: cover;
+}
+
+.carousel-container .carousel-3d-slide {
+  background-color: white;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 </style>

--- a/src/views/NovelDetailPage.vue
+++ b/src/views/NovelDetailPage.vue
@@ -111,6 +111,13 @@
           </div>
         </b-container>
       </article>
+      <div class="template-container">
+        <div id="suggest">
+          <b>찾으시는 웹소설이 없으신가요?</b>
+          <p>작품 신청을 통해 빠진 작품을 알려주세요!</p>
+          <b-button variant="info" @click="novelRequest()">신청하기</b-button>
+        </div>
+      </div>
     </main>
   </div>
 </template>
@@ -242,6 +249,9 @@ export default {
     async sleep(sec) {
       return new Promise((resolve) => setTimeout(resolve, sec));
     },
+    novelRequest() {
+      this.$router.push("/post/request");
+    },
   },
   components: {
     "novel-like": NovelLike,
@@ -256,5 +266,17 @@ export default {
   display: flex;
   justify-content: center;
   align-items: center;
+}
+#suggest {
+  font-size: 12px;
+  position: fixed;
+  top: 43%;
+  right: 1%;
+  transform: translateY(-50%);
+  background-color: white;
+  border-radius: 10px;
+  padding: 1%;
+  display: grid;
+  place-items: center;
 }
 </style>

--- a/src/views/NovelSearchPage.vue
+++ b/src/views/NovelSearchPage.vue
@@ -12,7 +12,7 @@
           buttons
         ></b-form-radio-group>
         <b-input-group prepend="제목" style="margin-top: 20px">
-          <b-form-input type="text" v-model="title" />
+          <b-form-input type="text" v-model="searchTitle" />
         </b-input-group>
         <b-input-group prepend="작가" style="margin-top: 20px">
           <b-form-input type="text" v-model="author" />
@@ -20,6 +20,14 @@
         </b-input-group>
       </b-form-group>
     </div>
+    <br />
+    <b-col md="6" offset-md="3">
+      <div class="descrption">
+        <b>찾으시는 웹소설이 없으신가요?</b>
+        <p>작품 신청을 통해 빠진 작품을 알려주세요!</p>
+        <b-button variant="info" @click="novelRequest()">신청하기</b-button>
+      </div>
+    </b-col>
     <div v-if="isEmpty">
       <h1>검색된 결과가 없습니다.</h1>
     </div>
@@ -114,6 +122,7 @@ export default {
         return;
       }
       try {
+        console.log(this.novelId);
         const res = await axios.get(
           `/api/v1/novel?novelId=${this.novelId}&title=${this.searchTitle}&author=${this.author}&genre=${this.selected}`
         );
@@ -147,6 +156,9 @@ export default {
     detailNovelList(novelId) {
       location.href = "/novel/" + novelId;
     },
+    novelRequest() {
+      this.$router.push("/post/request");
+    },
   },
   components: {
     InfiniteLoading,
@@ -159,6 +171,8 @@ export default {
   display: flex;
   justify-content: center;
   align-items: center;
+  display: flex;
+  flex-direction: row;
 }
 .title {
   margin: 20px;
@@ -180,5 +194,10 @@ export default {
   margin-top: 2%;
   margin-left: 5%;
   margin-right: 5%;
+}
+
+.descrption {
+  display: grid;
+  place-items: center;
 }
 </style>


### PR DESCRIPTION
### 📌 개발 개요
- resolve #57
- 팬클럽 페이지 작품 검색 기능 추가
- 작품 검색 창에서의 오류 수정
  <br>

### 💻  작업 및 변경 사항
- 검색, 작품 상세에서 작품 신청하기로 가기 위한 버튼 구성
- 팬클럽 페이지 
  - 최신 작가, 인기 채팅룸 추가
  - 작가 검색 기능 추가
- 메인 페이지
  - 최신 작가, 인기 리뷰 추가
- 검색 페이지에서 제목으로 검색 시 안되는 버그를 수정
  <br>

### ✅ Point
- 채팅방 참여를 위한 작가 정보를 불러올 때 작가의 rid를 받아오는 부분이 추가되어야 할 것 같습니다.
- 리뷰 검색에서 해당 리뷰를 눌렀을 때 해당 작품으로 가기 위해서 작품의 novelId값이 필요합니다.
  <br>