### PR TITLE
[FEAT] 마이페이지 프로필 수정 기능 구현

### DIFF
--- a/src/views/JoinPage.vue
+++ b/src/views/JoinPage.vue
@@ -81,7 +81,7 @@ export default {
             },
           };
 
-          const res = await axios.patch("/api/v1/user/me", obj, option);
+          const res = await axios.patch("/api/v1/user/join", obj, option);
           console.log(res.data);
           router.push({ path: "/" });
         } catch (err) {

--- a/src/views/MyPage.vue
+++ b/src/views/MyPage.vue
@@ -5,14 +5,23 @@
     <div>
       <label>이미지</label>
       <div>:<img :src="imageUrl" /></div>
+      <input type="file" ref="fileInput" accept="image/*" />
     </div>
     <div>
       <label>닉네임</label>
       <input type="text" v-model="nickname" />
-      <button>중복확인</button>
     </div>
+    <div>
+      <label>생년월일</label>
+      <input type="text" v-model="birth" readonly />
+    </div>
+    <div>
+      <label>성별</label>
+      <input type="text" v-model="gender" readonly />
+    </div>
+
     <button>회원탈퇴</button>
-    <button>회원수정</button>
+    <button @click="uploadImage">회원수정</button>
   </div>
 </template>
 
@@ -25,8 +34,47 @@ export default {
     return {
       token: null,
       nickname: "",
+      gender: "",
       imageUrl: "",
+      birth: "",
     };
+  },
+  methods: {
+    handleImageError(event) {
+      event.target.src =
+        "https://via.placeholder.com/600x600.png?text=No+Image";
+    },
+    async uploadImage() {
+      try {
+        const res = await axios.get("/api/v1/aws/s3");
+        const preSignedUrl = res.data.preSignedUrl;
+        const encodedFileName = res.data.encodedFileName;
+        try {
+          const fileInput = this.$refs.fileInput;
+          const file = fileInput.files[0];
+          await axios.put(preSignedUrl, file);
+          const uploadedUrl = `${process.env.VUE_APP_S3_PATH}/${encodedFileName}`;
+          this.imageUrl = uploadedUrl;
+        } catch (error) {
+          console.error(error);
+        }
+        const option = {
+          headers: {
+            Authorization: "Bearer " + this.$getAccessToken(),
+          },
+        };
+        await axios.patch(
+          "/api/v1/user/me",
+          {
+            nickname: this.nickname,
+            imageUrl: this.imageUrl,
+          },
+          option
+        );
+      } catch (err) {
+        console.error(err);
+      }
+    },
   },
   async created() {
     try {
@@ -38,6 +86,9 @@ export default {
       const res = await axios.get(`/api/v1/user/me`, option);
       console.log(res);
       this.nickname = res.data.nickname;
+      this.gender = res.data.gender;
+      this.imageUrl = res.data.imageUrl;
+      this.birth = res.data.birth;
     } catch (err) {
       console.log(err);
     }


### PR DESCRIPTION
### 📌 개발 개요
- resolve #51 
- 마이페이지 프로필 수정 기능 구현
  - 이미지 업로드
  - 정보 수정(닉네임)
  <br>

### 💻  작업 및 변경 사항
- 프로필 수정
  - 백엔드에 `Presigned URL` 요청
  - 받아온 `Presigend URL` 을 이용해서 S3에 이미지 업로드
  - 업로드한 URL과 변경된 정보를 백엔드에 수정 요청
- `JoinPage.vue` 의 API 경로 변경
  <br>

### ✅ Point
- 프론트 첫 작업이라 컨벤션 등 빠트린게 많을 수 있습니다 ㅎㅎ; 지적해주시면 감사히 수정하겠습니다.
- 원래 있던 페이지의 디자인 등은 수정하지 않고, API연결만 해뒀습니다.          
- [백엔드](https://github.com/TooNovel/TooNovel-BE/issues/52)            
  <br>