### PR TITLE
[BUG] 소설 상세 조회 페이지 로딩바

### DIFF
--- a/src/views/NovelDetailPage.vue
+++ b/src/views/NovelDetailPage.vue
@@ -3,7 +3,7 @@
     <div id="loading" v-if="isLoading" style="height: 600px">
       <div class="loader">Loading...</div>
     </div>
-    <main style="margin-top: 3%">
+    <main v-else style="margin-top: 3%">
       <article>
         <b-container class="bv-example-row">
           <b-row class="rows">
@@ -169,11 +169,11 @@ export default {
       selectedGrade: "--",
       novelLiked: false,
       userId: "",
-      isLoading: true,
-      accessToken: this.$getAccessToken(),
+      isLoading: false,
     };
   },
   async created() {
+    this.isLoading = true;
     await this.sleep(1500);
     try {
       if (this.$getAccessToken() != null) {
@@ -229,10 +229,22 @@ export default {
         );
         const newReview = res.data;
         this.reviews.push(newReview);
-        this.$router.go(0);
+        this.reviewContent = "";
+        this.reviewGrade = 0;
+        const id = this.$route.params.novel_id;
+        const reviewRes = await axios.get(
+          `${process.env.VUE_APP_API_URL}/review/` + id + "/novel"
+        );
+        this.reviews = reviewRes.data.content;
+        this.reviews.forEach((review) => {
+          review.createdDate = `${review.createdDate[0]} / ${review.createdDate[1]} / ${review.createdDate[2]}`;
+        });
       } catch (err) {
         if (this.$getAccessToken() == null || this.$getAccessToken() === "") {
           alert("로그인 후 리뷰 작성할 수 있습니다!");
+        }
+        if (err.response.data.code == "R002") {
+          alert(err.response.data.message);
         }
         console.log(err);
       }


### PR DESCRIPTION
### 📌 개발 개요
- #78 
- 소설 상세조회 시 로딩바와 함께 axios의 response를 받지않은 빈 화면이 동시에 그려지는 문제
  <br>

### 💻  작업 및 변경 사항
- `v-if, v-else` 를 사용해서 수정하였습니다.
  - axios 통신의 시작과 끝에서 `isLoading`를 토글하는 방식으로 동작합니다.
  <br>

### ✅ Point
- 일정상 급해서 문제가 심각한 소설 상세 조회에만 우선 작업했습니다. 이슈는 닫지 않겠습니다.               
- 사실 이후에 개선할 포인트가 많습니다.
  - 다른 페이지들에도 로딩 바를 사용한다면 컴포넌트로 분리해 두는 게 좀 더 좋을 것 같습니다.
  - vuex등에서 전역변수로 `isLoading`을 관리할 수 있을 것 같습니다.
  - axios에 인터셉터를 적용하는 방법으로 고도화할 수 있습니다.
  <br>