### PR TITLE
[BUG] 소설 전체 조회 페이지 로딩바 수정

### DIFF
--- a/src/views/NovelViewPage.vue
+++ b/src/views/NovelViewPage.vue
@@ -4,7 +4,7 @@
     <div id="loading" v-if="isLoading" style="height: 800px">
       <div class="loader">Loading...</div>
     </div>
-    <div class="novel-list-box" ref="allProductList">
+    <div v-else class="novel-list-box" ref="allProductList">
       <b-row>
         <b-col
           v-for="(novel, index) in novels"
@@ -31,6 +31,7 @@
       </b-row>
     </div>
     <infinite-loading
+      v-if="!isLoading"
       @infinite="infiniteHandler"
       spinner="waveDots"
     ></infinite-loading>


### PR DESCRIPTION
### 📌 개발 개요
- resolve #78 
- #81 
- 소설 전체 조회 페이지 로딩바 수정

  <br>

### 💻  작업 및 변경 사항
- v-if, v-else 를 사용해서 수정하였습니다.
  - #81 과 같습니다.
  - `response`가 오지않은 빈 화면이 로딩바 뒤편에 그려지는 문제를 수정하였습니다.
  - `infiniteHandler`가 첫 진입시에 그려지는 문제를 수정했습니다.
  <br>

### ✅ Point
- 관련된 이슈와 PR을 참고해주세요                         
  <br>