### PR TITLE
[BUG] 채팅방 관련 다수의 버그

### DIFF
--- a/src/views/ChatWindow.vue
+++ b/src/views/ChatWindow.vue
@@ -17,11 +17,19 @@
         <br />
         <div class="button-container">
           <button
+            v-if="loadChatLimiter < 31"
             class="w-btn-outline w-btn-indigo-outline"
             type="button"
             @click="loadChat()"
           >
             더보기
+          </button>
+          <button
+            v-if="loadChatLimiter >= 31"
+            class="w-btn-outline w-btn-indigo-outline"
+            type="button"
+          >
+            최근 30일까지의 채팅만 볼 수 있습니다.
           </button>
         </div>
         <div

--- a/src/views/ChatWindow.vue
+++ b/src/views/ChatWindow.vue
@@ -39,7 +39,7 @@
               </div>
             </div>
             <!-- 다른 사용자가 보낸 메세지 -->
-            <div v-if="chatting.senderId != users.userId">
+            <div v-if="chatting.senderId != users.userId || chatting.creator">
               <div class="anotherMsg">
                 <span class="anotherName">{{ chatting.senderName }}</span>
                 <div
@@ -55,9 +55,8 @@
                 </div>
               </div>
             </div>
-            <!-- filtered 클래스에 블러 스타일 적용해주시면 됩니다 -->
           </div>
-          <!-- reply는 일단 스타일 적용 안했습니다 -->
+          <!-- 답장 -->
           <div class="chat reply" v-if="chatting.replyId != null">
             답장 : {{ chatting.replyMessage }}
           </div>
@@ -177,7 +176,8 @@ export default {
           const tempChatList = chatRes.data.filter((chat) => {
             if (
               chat.senderId == this.users.userId || // 내가 보낸 채팅은 보이게
-              this.users.role == "AUTHOR" // 내가 작가면 전부 보이게
+              this.users.role == "AUTHOR" || // 내가 작가면 전부 보이게
+              chat.creator // 작가의 채팅도 보이게
             )
               return chat;
           });

--- a/src/views/ChatWindow.vue
+++ b/src/views/ChatWindow.vue
@@ -42,16 +42,10 @@
             <div v-if="chatting.senderId != users.userId || chatting.creator">
               <div class="anotherMsg">
                 <span class="anotherName">{{ chatting.senderName }}</span>
-                <div
-                  v-if="!chatting.creator"
-                  :class="{ filtered: isFiltered(chatting.filterResult) }"
-                >
+                <div :class="{ filtered: isFiltered(chatting.filterResult) }">
                   <div class="msg" @click="cancleFilter(chatting.filterResult)">
                     {{ chatting.message }}
                   </div>
-                </div>
-                <div v-else>
-                  <div class="msg">{{ chatting.message }}</div>
                 </div>
               </div>
             </div>

--- a/src/views/ChatWindow.vue
+++ b/src/views/ChatWindow.vue
@@ -39,7 +39,12 @@
               </div>
             </div>
             <!-- 다른 사용자가 보낸 메세지 -->
-            <div v-if="chatting.senderId != users.userId || chatting.creator">
+            <div
+              v-if="
+                chatting.senderId != users.userId ||
+                (chatting.creator && chatting.senderId != users.userId)
+              "
+            >
               <div class="anotherMsg">
                 <span class="anotherName">{{ chatting.senderName }}</span>
                 <div :class="{ filtered: isFiltered(chatting.filterResult) }">
@@ -218,7 +223,12 @@ export default {
             console.log("room's tick", tick);
             const chatting = JSON.parse(tick.body);
             // 채팅방에서 수신된 메시지 처리. 정상 작동
-            this.chattingList.unshift(chatting);
+            if (
+              chatting.senderId == this.users.userId || // 내가 보낸 채팅은 보이게
+              this.users.role == "AUTHOR" || // 내가 작가면 전부 보이게
+              chatting.creator // 작가의 채팅도 보이게
+            )
+              this.chattingList.unshift(chatting);
             setTimeout(() => {
               window.scrollTo(
                 0,
@@ -269,7 +279,6 @@ export default {
       });
     },
     isFiltered(msg) {
-      console.log(msg);
       return msg == "bad" ? true : false;
     },
   },

--- a/src/views/ChatWindow.vue
+++ b/src/views/ChatWindow.vue
@@ -43,7 +43,7 @@
               <div class="anotherMsg">
                 <span class="anotherName">{{ chatting.senderName }}</span>
                 <div :class="{ filtered: isFiltered(chatting.filterResult) }">
-                  <div class="msg" @click="cancleFilter(chatting.filterResult)">
+                  <div class="msg" @click="cancleFilter(chatting)">
                     {{ chatting.message }}
                   </div>
                 </div>
@@ -131,11 +131,8 @@ export default {
     }
   },
   methods: {
-    async cancleFilter(res) {
-      if (res == "bad") {
-        const ok = "ok";
-        this.isFiltered(ok);
-      }
+    async cancleFilter(chat) {
+      chat.filterResult = "ok";
     },
     async toChatRoom() {
       location.href = "/chatRoom";

--- a/src/views/ChatWindow.vue
+++ b/src/views/ChatWindow.vue
@@ -30,14 +30,16 @@
           :key="index"
           ref="chatLog"
         >
+          <!-- 일반 채팅(답장이 아닌 채팅) -->
           <div v-if="chatting.replyId == null">
+            <!-- 보낸 사람 = 나 -->
             <div v-if="chatting.senderId == users.userId">
               <div class="myMsg">
                 <div class="msg">{{ chatting.message }}</div>
               </div>
             </div>
             <!-- 다른 사용자가 보낸 메세지 -->
-            <div v-else>
+            <div v-if="chatting.senderId != users.userId">
               <div class="anotherMsg">
                 <span class="anotherName">{{ chatting.senderName }}</span>
                 <div
@@ -171,8 +173,13 @@ export default {
             }?date=${this.date.getFullYear()}-${month}-${day}`,
             option
           );
+          console.log(chatRes.data);
           const tempChatList = chatRes.data.filter((chat) => {
-            if (chat.senderId == this.users.userId) return chat;
+            if (
+              chat.senderId == this.users.userId || // 내가 보낸 채팅은 보이게
+              this.users.role == "AUTHOR" // 내가 작가면 전부 보이게
+            )
+              return chat;
           });
 
           // reply 요청


### PR DESCRIPTION
### 📌 개발 개요
- resolve #84 

> - 타인이 보낸 이전 메세지 조회 불가
>   - API 요청은 정상적으로 오지만, 화면에 그려지지 않음
>   - WebSocket을 통한 메세지는 정상적으로 조회 가능
> 
> - 독자가 다른 독자의 일반 메세지를 확인 가능
>    - 일대다 (혹은 허브 앤 스포크) 구조로써 독자는 작가의 메세지와, 작가가 특정 메세지에 대해 답장을 보냈을 경우에만 볼 수 있는 것이 정상
> 
> - 블러처리된 메세지를 블러해제 할 수 없는 현상

  <br>

### 💻  작업 및 변경 사항
- 타인이 보낸 메세지 조회 불가능한 버그 해결
- 작가의 채팅이 필터링되지 않는 버그 해결
- 필터링 블러가 해제되지 않는 문제 해결
- 채팅 조회 제한(최근 30일까지)이 지나면 버튼 변경하여 알려주도록 수정
- 채팅방에 처음 접속하면 최근 일주일간의 메세지가 모두 보이도록 수정
  <br>

### ✅ Point
- 채팅방 조회 로직은 추후에 백엔드 포함해서 수정 예정입니다
- 답장 기능은 다른 이슈에서 다루겠습니다
- 커밋을 잘게 쪼개놨습니다. 리뷰하실때 커밋 단위로 보시는게 편할겁니다
  <br>