### PR TITLE
[REFACTOR]통계 페이지 리팩터링

### DIFF
--- a/src/views/AdminPage.vue
+++ b/src/views/AdminPage.vue
@@ -1,13 +1,38 @@
 <template>
   <div>
     <MyPageNavbar></MyPageNavbar>
-    <div class="chart-container">
-      <h1>일별 리뷰 데이터</h1>
-      <canvas class="review-chart" ref="reviewChart"></canvas>
+    <div class="info">
+      <h2>
+        기본 통계데이터는 저번주부터 오늘까지 총 1주일간의데이터를 제공합니다.
+      </h2>
     </div>
-    <div class="chart-container">
-      <h1>일별 작품 데이터</h1>
-      <canvas class="novel-chart" ref="novelChart"></canvas>
+    <div class="review-box">
+      <div>
+        <h2>리뷰 데이터 조회 날짜 선택</h2>
+        <input type="date" id="start-date" v-model="reviewStartDate" />
+        <br />
+        <input type="date" id="end-date" v-model="reviewEndDate" />
+        <br />
+        <button @click="reviewDate()">날짜 선택</button>
+      </div>
+      <div class="chart-container">
+        <h1>일별 리뷰 데이터</h1>
+        <canvas ref="reviewChart" width="200"></canvas>
+      </div>
+    </div>
+    <div class="novel-box">
+      <div>
+        <h2>웹소설 데이터 조회 날짜 선택</h2>
+        <input type="date" id="start-date" v-model="novelStartDate" />
+        <br />
+        <input type="date" id="end-date" v-model="novelEndDate" />
+        <br />
+        <button @click="novelDate()">날짜 선택</button>
+      </div>
+      <div class="chart-container">
+        <h1>일별 작품 데이터</h1>
+        <canvas ref="novelChart" width="200"></canvas>
+      </div>
     </div>
   </div>
 </template>
@@ -35,7 +60,61 @@ export default {
       reviewIdxCount: [],
       novelIdxValue: [],
       novelIdxCount: [],
+      reviewStartDate: "",
+      reviewEndDate: "",
+      novelStartDate: "",
+      novelEndDate: "",
     };
+  },
+  methods: {
+    async reviewDate() {
+      const startDate = this.reviewStartDate;
+      const endDate = this.reviewEndDate;
+      if (startDate > endDate) {
+        alert("시작날짜가 더 클수 없습니다");
+        return;
+      } else if (startDate == "" || endDate == "") {
+        alert("날짜를 선택해주세요");
+        return;
+      }
+      try {
+        const reviewRes = await axios.get(
+          `${process.env.VUE_APP_API_URL}/admin/review?startDate=${startDate}&endDate=${endDate}`
+        );
+        this.reviewstatistics = reviewRes.data;
+        this.reviewIdxValue = this.reviewstatistics.map((i) => i.createdDate);
+        this.reviewIdxCount = this.reviewstatistics.map((i) => i.count);
+        this.reviewChart.data.labels = this.reviewIdxValue;
+        this.reviewChart.data.datasets[0].data = this.reviewIdxCount;
+        this.reviewChart.update();
+      } catch (err) {
+        console.log(err);
+      }
+    },
+    async novelDate() {
+      const startDate = this.novelStartDate;
+      const endDate = this.novelEndDate;
+      if (startDate > endDate) {
+        alert("시작날짜가 더 클수 없습니다");
+        return;
+      } else if (startDate == "" || endDate == "") {
+        alert("날짜를 선택해주세요");
+        return;
+      }
+      try {
+        const novelRes = await axios.get(
+          `${process.env.VUE_APP_API_URL}/admin/novel?startDate=${startDate}&endDate=${endDate}`
+        );
+        this.novelstatistics = novelRes.data;
+        this.novelIdxValue = this.novelstatistics.map((i) => i.createdDate);
+        this.novelIdxCount = this.novelstatistics.map((i) => i.count);
+        this.novelChart.data.labels = this.novelIdxValue;
+        this.novelChart.data.datasets[0].data = this.novelIdxCount;
+        this.novelChart.update();
+      } catch (err) {
+        console.log(err);
+      }
+    },
   },
   async mounted() {
     try {
@@ -45,8 +124,6 @@ export default {
       const novelRes = await axios.get(
         `${process.env.VUE_APP_API_URL}/admin/novel`
       );
-      console.log(reviewRes.data);
-      console.log(novelRes.data);
       //리뷰데이터 + 리뷰차트
       this.reviewstatistics = reviewRes.data;
       this.reviewIdxValue = this.reviewstatistics.map((i) => i.createdDate);
@@ -57,7 +134,6 @@ export default {
       this.novelstatistics = novelRes.data;
       this.novelIdxValue = this.novelstatistics.map((i) => i.createdDate);
       this.novelIdxCount = this.novelstatistics.map((i) => i.count);
-      this.novelIdxCount[0] = 0;
       const ctx2 = this.$refs.novelChart.getContext("2d");
 
       this.reviewChart = new Chart(ctx, {
@@ -144,17 +220,31 @@ export default {
     } catch (err) {
       console.log(err);
     }
-
     this.reviewChart.options.scales.y.beginAtZero = true;
-    this.reviewChart.update();
+    this.novelChart.options.scales.y.beginAtZero = true;
   },
   components: { MyPageNavbar },
 };
 </script>
 <style scope>
+.info {
+  background-color: white;
+  border-radius: 30px;
+  margin: 10px;
+}
+.review-box {
+  background-color: white;
+  border-radius: 30px;
+  margin: 10px;
+}
+.novel-box {
+  background-color: white;
+  border-radius: 30px;
+  margin-top: 100px;
+}
 .chart-container {
-  width: 70rem; /* 원하는 가로 크기 */
-  height: 30rem; /* 원하는 세로 크기 */
+  background-color: rgb(133, 185, 138);
+  border-radius: 30px;
   margin-top: 70px;
 }
 </style>

--- a/src/views/AdminPage.vue
+++ b/src/views/AdminPage.vue
@@ -163,7 +163,7 @@ export default {
               callbacks: {
                 label: (context) => {
                   const data = context.parsed.y;
-                  return `데이터 개수 : ${data}`;
+                  return `추가된 리뷰 개수 : ${data}`;
                 },
               },
             },
@@ -210,7 +210,7 @@ export default {
               callbacks: {
                 label: (context) => {
                   const data = context.parsed.y;
-                  return `데이터 개수 : ${data}`;
+                  return `추가된 웹소설 개수 : ${data}`;
                 },
               },
             },

--- a/src/views/NovelStatisticsPage.vue
+++ b/src/views/NovelStatisticsPage.vue
@@ -2,16 +2,16 @@
   <div>
     <main style="margin-top: 3%">
       <MyPageNavbar></MyPageNavbar>
-      <div id="writerStatistics">
+      <div class="chart-wrap">
         <div v-if="reviews.length == 0">아직 통계가 없습니다.</div>
         <div v-else>
-          <div id="statistics1">
+          <div class="age-chart-container">
             연령대별 통계
-            <canvas ref="genderChart" width="400" height="400"></canvas>
+            <canvas ref="genderChart" width="400px" height="400px"></canvas>
           </div>
-          <div id="statistics1">
+          <div class="gender-chart-container">
             성별 통계
-            <canvas ref="ageChart" width="400" height="400"></canvas>
+            <canvas ref="ageChart" width="500px" height="500px"></canvas>
           </div>
         </div>
       </div>
@@ -94,9 +94,18 @@ import {
   CategoryScale,
   LinearScale,
   BarElement,
+  PieController,
+  ArcElement,
 } from "chart.js";
 
-Chart.register(BarController, CategoryScale, LinearScale, BarElement);
+Chart.register(
+  BarController,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  PieController,
+  ArcElement
+);
 
 export default {
   name: "NovelDetailPage",
@@ -199,7 +208,7 @@ export default {
         },
       });
       this.ageChart = new Chart(ctx2, {
-        type: "bar",
+        type: "pie",
         data: {
           labels: ["남성", "여성"],
           datasets: [
@@ -216,17 +225,23 @@ export default {
           ],
         },
         options: {
-          responsive: false,
-          scales: {
-            y: {
-              type: "linear",
-              ticks: {
-                beginAtZero: true,
-                maxTicksLimit: 3,
-                callback: function (value) {
-                  return Math.floor(value);
-                },
-              },
+          responsive: true,
+          legend: {
+            position: "top",
+            fontColor: "black",
+            align: "center",
+            display: true,
+            fullWidth: true,
+            labels: {
+              fontColor: "rgb(0, 0, 0)",
+            },
+          },
+          plugins: {
+            labels: {
+              render: "value",
+              fontColor: "black",
+              fontSize: 15,
+              precision: 2,
             },
           },
         },
@@ -291,15 +306,23 @@ export default {
 </script>
 <style scoped>
 @import "@/style/novel-detail.css";
-
-#writerStatistics {
-  width: 800px;
-  display: inline;
+.chart-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100rem;
+  overflow: hidden;
+  margin-bottom: 50px;
 }
-#statistics1 {
-  width: 400px;
+.age-chart-container {
+  display: block;
+  float: left;
+  width: 50rem; /* 원하는 가로 크기 */
 }
-#statistics2 {
-  width: 400px;
+.gender-chart-container {
+  display: block;
+  float: left;
+  width: 50rem; /* 원하는 가로 크기 */
+  height: 20rem; /* 원하는 세로 크기 */
 }
 </style>


### PR DESCRIPTION
### 📌 개발 개요
- resolve #88 
  <br>

### 💻  작업 및 변경 사항
- 작가 통계 페이지
  - 기존 바 모양 차트로 연령대별, 성별 통계 구현했는데 연령대는 바모양 차트 그대로, 성별은 파이모양 차트로 바꿔서 구현하였습니다.
- 관리자 통계 페이지
  - 기존에는 리뷰 및 웹소설 테이블에 존재하는 모든 날짜를 가져와서 조회하도록 하였는데
  - 첫 통계 페이지 진입시에는 오늘날짜부터 지난 주 1주일 동안의 통계 데이터를 제공하고
  - 더 다양한 날짜를 보고 싶다면 input 태그를 통해 조회하고 싶은 기간 동안의 시작날짜와 끝날짜를 입력하면 해당되는 날짜의 통계 데이터가 나타나도록 구현하였습니다.
- 관리자 통계 페이지만 일부 css적용하였습니다.
  <br>

### ✅ Point
- css는 추후 더 보완할 예정입니다. 그래도 나름 예쁘게 꾸몄는데 관리자 계정으로 들어가서 통계페이지 한번 보시는 것 추천드립니다.