### PR TITLE
[FEAT] 답장 기능 구현

### DIFF
--- a/src/store/store.js
+++ b/src/store/store.js
@@ -8,25 +8,18 @@ const store = new Vuex.Store({
   plugins: [createPersistedState()],
   // [변수들의 집합]
   state: {
-    accessToken: null,
-    refreshToken: null,
+    chatRoomName: null,
   },
   // [변수들을 조작하는 함수들]
   mutations: {
-    setAccessToken(state, accessToken) {
-      state.accessToken = accessToken;
-    },
-    setRefreshToken(state, refreshToken) {
-      state.refreshToken = refreshToken;
+    setChatRoomName(state, chatRoomName) {
+      state.chatRoomName = chatRoomName;
     },
   },
   // [state의 변수들을 get 호출]
   getters: {
-    getAccessToken(state) {
-      return state.accessToken;
-    },
-    getRefreshToken(state) {
-      return state.refreshToken;
+    getChatRoomName(state) {
+      return state.chatRoomName;
     },
   },
 });

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -9,17 +9,24 @@ const store = new Vuex.Store({
   // [변수들의 집합]
   state: {
     chatRoomName: null,
+    chatOwnerNickname: null,
   },
   // [변수들을 조작하는 함수들]
   mutations: {
     setChatRoomName(state, chatRoomName) {
       state.chatRoomName = chatRoomName;
     },
+    setChatOwnerNickname(state, nickname) {
+      state.chatOwnerNickname = nickname;
+    },
   },
   // [state의 변수들을 get 호출]
   getters: {
     getChatRoomName(state) {
       return state.chatRoomName;
+    },
+    getChatOwnerNickname(state) {
+      return state.chatOwnerNickname;
     },
   },
 });

--- a/src/views/ChatRoom.vue
+++ b/src/views/ChatRoom.vue
@@ -30,7 +30,6 @@
 </template>
 
 <script>
-import axios from "axios";
 import MyChatRoom from "./MyChatRoom.vue";
 import MyFollowChat from "./MyFollowChat.vue";
 
@@ -41,26 +40,14 @@ export default {
       roomId: "", // 추후에 api 통신으로 받아올것
       user: {}, // userId, nickname...
       chatRoomName: "",
-      //isCreator: true, // true 이면 작가, false면 독자
-      chatList: [],
       role: null,
     };
   },
   async created() {
-    const option = {
-      headers: {
-        Authorization: "Bearer " + this.$getAccessToken(),
-      },
-    };
     try {
-      const chat = await axios.get(
-        `${process.env.VUE_APP_API_URL}/chat`,
-        option
-      );
       const accessToken = this.$getAccessToken();
       const role = this.$getTokenInfo(accessToken).role;
       this.role = role;
-      this.chatList = chat.data;
     } catch (err) {
       console.log(err);
     }

--- a/src/views/ChatRoom.vue
+++ b/src/views/ChatRoom.vue
@@ -39,7 +39,6 @@ export default {
     return {
       roomId: "", // 추후에 api 통신으로 받아올것
       user: {}, // userId, nickname...
-      chatRoomName: "",
       role: null,
     };
   },

--- a/src/views/ChatWindow.vue
+++ b/src/views/ChatWindow.vue
@@ -60,7 +60,6 @@
                     {{ chatting.message }}
                   </div>
                   <!-- 위 div에 마우스 호버되면 아래 span이 보이도록 구상중 -->
-                  <!-- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@작가만 답장 버튼 보이도록 구성해야함 -->
                   <span
                     @click="selectMsg(chatting)"
                     v-if="chatOwnerNickname == users.nickname"
@@ -71,8 +70,26 @@
             </div>
           </div>
           <!-- 답장 -->
-          <div class="chat reply" v-if="chatting.replyId != null">
-            답장 : {{ chatting.replyMessage }}
+          <div v-if="chatting.replyId != null">
+            <!-- 내가 채팅방 주인이면 -->
+            <div class="myMsg" v-if="chatOwnerNickname == users.nickname">
+              <div class="msg">
+                <div class="reply-msg-sendername">{{ chatting.userName }}</div>
+                <div class="reply-msg">{{ chatting.userMessage }}</div>
+                <hr />
+                답장 : {{ chatting.replyMessage }}
+              </div>
+            </div>
+            <!-- 내가 채팅방 주인이 아니면 -->
+            <div class="anotherMsg" v-if="chatOwnerNickname != users.nickname">
+              <span class="anotherName">{{ chatting.senderName }}</span>
+              <div class="msg">
+                <div class="reply-msg-sendername">{{ chatting.userName }}</div>
+                <div class="reply-msg">{{ chatting.userMessage }}</div>
+                <hr />
+                {{ chatting.replyMessage }}
+              </div>
+            </div>
           </div>
         </div>
         <div>
@@ -535,5 +552,13 @@ body {
 }
 .send:hover {
   background-color: rgb(131, 171, 131);
+}
+.reply-msg-sendername {
+  color: gray;
+  font-size: small;
+}
+.reply-msg {
+  /* color: gray; */
+  font-size: small;
 }
 </style>

--- a/src/views/ChatWindow.vue
+++ b/src/views/ChatWindow.vue
@@ -9,7 +9,7 @@
             </div>
             <header class="col-10">
               <div class="row">
-                <div class="col-10">{{ this.nickname }}의 채팅방</div>
+                <div class="col-10">{{ this.chatRoomName }}</div>
               </div>
             </header>
           </div>
@@ -108,6 +108,7 @@ export default {
       replyState: false,
       date: null,
       loadChatLimiter: 0,
+      chatRoomName: null,
     };
   },
   async created() {
@@ -139,6 +140,10 @@ export default {
       setTimeout(() => {
         window.scrollTo(0, document.getElementById("contentWrap").scrollHeight);
       }, 100);
+
+      // 화면 상단 표시용
+      this.chatRoomName = this.$store.getters.getChatRoomName;
+      this.$store.commit("setChatRoomName", null);
     } catch (err) {
       console.log(err);
     }

--- a/src/views/MyChatRoom.vue
+++ b/src/views/MyChatRoom.vue
@@ -105,6 +105,7 @@ export default {
   methods: {
     async ToChatting(res) {
       try {
+        this.$store.commit("setChatRoomName", res.chatRoomName);
         const roomId = res.chatRoomId;
         location.href = `/chatWindow/${roomId}`;
       } catch (err) {

--- a/src/views/MyFollowChat.vue
+++ b/src/views/MyFollowChat.vue
@@ -81,6 +81,7 @@ export default {
     async ToMyFollwingChat(res) {
       try {
         this.$store.commit("setChatRoomName", res.chatRoomName);
+        this.$store.commit("setChatOwnerNickname", res.nickname);
         const roomId = res.chatRoomId;
         location.href = `/chatWindow/${roomId}`;
       } catch (err) {

--- a/src/views/MyFollowChat.vue
+++ b/src/views/MyFollowChat.vue
@@ -80,6 +80,7 @@ export default {
   methods: {
     async ToMyFollwingChat(res) {
       try {
+        this.$store.commit("setChatRoomName", res.chatRoomName);
         const roomId = res.chatRoomId;
         location.href = `/chatWindow/${roomId}`;
       } catch (err) {


### PR DESCRIPTION
### 📌 개발 개요
- resolve #85

> 독자의 메세지에 대한 답장 기능 구현

  <br>

### 💻  작업 및 변경 사항
- 불필요한 axios 요청 삭제
- 채팅방 상단에 채팅방 이름이 아니라, 접속 유저 닉네임이 나오던 문제 수정
- 채팅에 대한 답장 기능 구현
  <br>

### ✅ Point
- 현재 새로고침 시 문제가 생깁니다.
  - 새로고침 시 발생하는 문제를 해결하는 것도 가능하지만, 새로고침 시 채팅방 목록으로 나가지는 것으로 수정하려 합니다
    - 새로고침 도중 발송된 웹소켓 메세지가 정상적으로 도착하기 않거나, 비정상적인 커넥션이 생길 수 있기 때문입니다.
- 답장을 하기 위한 ui의 디자인 작업이 되어있지 않습니다
- 답장을 하기 위한 버튼이 디자인되지 않았습니다
  - 기존에 생각한 것은 마우스 호버 시 답장 버튼이 보이는 것 입니다
  <br>