### PR TITLE
[FEAT] 필터링된 메세지에 대한 답장 경고

### DIFF
--- a/src/store/store.js
+++ b/src/store/store.js
@@ -9,15 +9,15 @@ const store = new Vuex.Store({
   // [변수들의 집합]
   state: {
     chatRoomName: null,
-    chatOwnerNickname: null,
+    chatOwner: null,
   },
   // [변수들을 조작하는 함수들]
   mutations: {
     setChatRoomName(state, chatRoomName) {
       state.chatRoomName = chatRoomName;
     },
-    setChatOwnerNickname(state, nickname) {
-      state.chatOwnerNickname = nickname;
+    setChatOwner(state, id) {
+      state.chatOwner = id;
     },
   },
   // [state의 변수들을 get 호출]
@@ -25,8 +25,8 @@ const store = new Vuex.Store({
     getChatRoomName(state) {
       return state.chatRoomName;
     },
-    getChatOwnerNickname(state) {
-      return state.chatOwnerNickname;
+    getChatOwner(state) {
+      return state.chatOwner;
     },
   },
 });

--- a/src/views/ChatWindow.vue
+++ b/src/views/ChatWindow.vue
@@ -15,80 +15,86 @@
           </div>
         </div>
         <br />
-        <div class="button-container">
-          <button
-            v-if="loadChatLimiter < 31"
-            class="w-btn-outline w-btn-indigo-outline"
-            type="button"
-            @click="loadChat()"
-          >
-            더보기
-          </button>
-          <button
-            v-if="loadChatLimiter >= 31"
-            class="w-btn-outline w-btn-indigo-outline"
-            type="button"
-          >
-            최근 30일까지의 채팅만 볼 수 있습니다.
-          </button>
-        </div>
-        <div
-          id="chatLog"
-          v-for="(chatting, index) in chattingList.slice().reverse()"
-          :key="index"
-          ref="chatLog"
-        >
-          <!-- 일반 채팅(답장이 아닌 채팅) -->
-          <div v-if="chatting.replyId == null">
-            <!-- 보낸 사람 = 나 -->
-            <div v-if="chatting.senderId == users.userId">
-              <div class="myMsg">
-                <div class="msg">{{ chatting.message }}</div>
-              </div>
-            </div>
-            <!-- 다른 사용자가 보낸 메세지 -->
-            <div
-              v-if="
-                chatting.senderId != users.userId ||
-                (chatting.creator && chatting.senderId != users.userId)
-              "
+        <div class="chat-container">
+          <div class="button-container">
+            <button
+              v-if="loadChatLimiter < 31"
+              class="w-btn-outline w-btn-indigo-outline"
+              type="button"
+              @click="loadChat()"
             >
-              <div class="anotherMsg">
-                <span class="anotherName">{{ chatting.senderName }}</span>
-                <div :class="{ filtered: isFiltered(chatting.filterResult) }">
-                  <div class="msg" @click="cancleFilter(chatting)">
-                    {{ chatting.message }}
+              더보기
+            </button>
+            <button
+              v-if="loadChatLimiter >= 31"
+              class="w-btn-outline w-btn-indigo-outline"
+              type="button"
+            >
+              최근 30일까지의 채팅만 볼 수 있습니다.
+            </button>
+          </div>
+          <div
+            id="chatLog"
+            v-for="(chatting, index) in chattingList.slice().reverse()"
+            :key="index"
+            ref="chatLog"
+          >
+            <!-- 일반 채팅(답장이 아닌 채팅) -->
+            <div v-if="chatting.replyId == null">
+              <!-- 보낸 사람 = 나 -->
+              <div v-if="chatting.senderId == users.userId">
+                <div class="myMsg">
+                  <div class="msg">{{ chatting.message }}</div>
+                </div>
+              </div>
+              <!-- 다른 사용자가 보낸 메세지 -->
+              <div
+                v-if="
+                  chatting.senderId != users.userId ||
+                  (chatting.creator && chatting.senderId != users.userId)
+                "
+              >
+                <div class="anotherMsg">
+                  <span class="anotherName">{{ chatting.senderName }}</span>
+                  <div :class="{ filtered: isFiltered(chatting.filterResult) }">
+                    <div class="msg" @click="cancleFilter(chatting)">
+                      {{ chatting.message }}
+                    </div>
+                    <!-- 위 div에 마우스 호버되면 아래 span이 보이도록 구상중 -->
+                    <span
+                      @click="selectMsg(chatting)"
+                      v-if="chatOwner == users.userId"
+                    >
+                      <span>답장</span>
+                    </span>
                   </div>
-                  <!-- 위 div에 마우스 호버되면 아래 span이 보이도록 구상중 -->
-                  <span
-                    @click="selectMsg(chatting)"
-                    v-if="chatOwner == users.userId"
-                  >
-                    <span>답장</span>
-                  </span>
                 </div>
               </div>
             </div>
-          </div>
-          <!-- 답장 -->
-          <div v-if="chatting.replyId != null">
-            <!-- 내가 채팅방 주인이면 -->
-            <div class="myMsg" v-if="chatOwner == users.userId">
-              <div class="msg">
-                <div class="reply-msg-sendername">{{ chatting.userName }}</div>
-                <div class="reply-msg">{{ chatting.userMessage }}</div>
-                <hr />
-                {{ chatting.replyMessage }}
+            <!-- 답장 -->
+            <div v-if="chatting.replyId != null">
+              <!-- 내가 채팅방 주인이면 -->
+              <div class="myMsg" v-if="chatOwner == users.userId">
+                <div class="msg">
+                  <div class="reply-msg-sendername">
+                    {{ chatting.userName }}
+                  </div>
+                  <div class="reply-msg">{{ chatting.userMessage }}</div>
+                  <hr />
+                  {{ chatting.replyMessage }}
+                </div>
               </div>
-            </div>
-            <!-- 내가 채팅방 주인이 아니면 -->
-            <div class="anotherMsg" v-if="chatOwner != users.userId">
-              <span class="anotherName">{{ chatting.senderName }}</span>
-              <div class="msg">
-                <div class="reply-msg-sendername">{{ chatting.userName }}</div>
-                <div class="reply-msg">{{ chatting.userMessage }}</div>
-                <hr />
-                {{ chatting.replyMessage }}
+              <!-- 내가 채팅방 주인이 아니면 -->
+              <div class="anotherMsg" v-if="chatOwner != users.userId">
+                <span class="anotherName">{{ chatting.senderName }}</span>
+                <div class="msg">
+                  <div class="reply-msg-sendername">
+                    {{ chatting.userName }}
+                  </div>
+                  <div class="reply-msg">{{ chatting.userMessage }}</div>
+                  <hr />
+                  {{ chatting.replyMessage }}
+                </div>
               </div>
             </div>
           </div>
@@ -594,5 +600,22 @@ body {
   text-align: center;
   align-self: center;
   color: gray;
+}
+.chat-container {
+  height: calc(85% - 3rem) !important;
+  overflow: hidden scroll;
+}
+#contentWrap,
+#contentCover,
+#chatWrap {
+  height: calc(100% - 3rem) !important;
+}
+div::-webkit-scrollbar {
+  width: 4px; /* 스크롤바의 너비 */
+}
+div::-webkit-scrollbar-thumb {
+  height: 30%; /* 스크롤바의 길이 */
+  background: #ccc; /* 스크롤바의 색상 */
+  border-radius: 10px;
 }
 </style>

--- a/src/views/ChatWindow.vue
+++ b/src/views/ChatWindow.vue
@@ -144,6 +144,14 @@ export default {
   },
   async created() {
     try {
+      // 비정상적인 요청
+      this.chatOwnerNickname = await this.$store.getters.getChatOwnerNickname;
+      this.chatRoomName = await this.$store.getters.getChatRoomName;
+      if (this.chatOwnerNickname == null || this.chatRoomName == null) {
+        this.$router.push({ name: "ChatRoom" });
+        return;
+      }
+
       // 초기 설정
       this.date = new Date();
       const accessToken = this.$getAccessToken();
@@ -161,7 +169,6 @@ export default {
         option
       );
       this.nickname = user.data.nickname;
-      this.chatOwnerNickname = this.$store.getters.getChatOwnerNickname;
       this.$store.commit("setChatOwnerNickname", null);
 
       // 웹소켓 연결
@@ -175,7 +182,6 @@ export default {
       }, 100);
 
       // 화면 상단 표시용
-      this.chatRoomName = this.$store.getters.getChatRoomName;
       this.$store.commit("setChatRoomName", null);
     } catch (err) {
       console.log(err);

--- a/src/views/ChatWindow.vue
+++ b/src/views/ChatWindow.vue
@@ -63,8 +63,9 @@
                   <span
                     @click="selectMsg(chatting)"
                     v-if="chatOwner == users.userId"
-                    >답장</span
                   >
+                    <span>답장</span>
+                  </span>
                 </div>
               </div>
             </div>
@@ -94,8 +95,10 @@
         </div>
         <div>
           <div v-if="isReply">
-            <span>{{ replyChat.message }}</span>
-            <span @click="cancleReply()">X</span>
+            <div class="reply-box">
+              <span class="reply-box-msg">{{ replyChat.message }}</span>
+              <span class="reply-box-cancle" @click="cancleReply()">X</span>
+            </div>
           </div>
           <form id="chatForm">
             <div>
@@ -577,5 +580,19 @@ body {
 .reply-msg {
   /* color: gray; */
   font-size: small;
+}
+.reply-box {
+  display: flex;
+  background-color: #f5f5f5;
+  padding: 10px;
+}
+.reply-box-msg {
+  width: 95%;
+}
+.reply-box-cancle {
+  width: 5%;
+  text-align: center;
+  align-self: center;
+  color: gray;
 }
 </style>

--- a/src/views/ChatWindow.vue
+++ b/src/views/ChatWindow.vue
@@ -77,7 +77,7 @@
                 <div class="reply-msg-sendername">{{ chatting.userName }}</div>
                 <div class="reply-msg">{{ chatting.userMessage }}</div>
                 <hr />
-                답장 : {{ chatting.replyMessage }}
+                {{ chatting.replyMessage }}
               </div>
             </div>
             <!-- 내가 채팅방 주인이 아니면 -->
@@ -189,7 +189,7 @@ export default {
   },
   methods: {
     async cancleFilter(chat) {
-      chat.filterResult = "ok";
+      chat.filterResult = "open";
     },
     async toChatRoom() {
       location.href = "/chatRoom";
@@ -441,8 +441,19 @@ export default {
       return msg == "bad" ? true : false;
     },
     selectMsg(chatting) {
-      this.isReply = true;
-      this.replyChat = chatting;
+      if (chatting.filterResult != "ok") {
+        if (
+          confirm(
+            "해당 메세지는 다른 사용자에게 불쾌감을 줄 수 있습니다. 진행하시겠습니까?"
+          )
+        ) {
+          this.isReply = true;
+          this.replyChat = chatting;
+        }
+      } else {
+        this.isReply = true;
+        this.replyChat = chatting;
+      }
     },
     cancleReply() {
       this.isReply = false;

--- a/src/views/ChatWindow.vue
+++ b/src/views/ChatWindow.vue
@@ -62,7 +62,7 @@
                   <!-- 위 div에 마우스 호버되면 아래 span이 보이도록 구상중 -->
                   <span
                     @click="selectMsg(chatting)"
-                    v-if="chatOwnerNickname == users.nickname"
+                    v-if="chatOwnerNickname == nickname"
                     >답장</span
                   >
                 </div>
@@ -72,7 +72,7 @@
           <!-- 답장 -->
           <div v-if="chatting.replyId != null">
             <!-- 내가 채팅방 주인이면 -->
-            <div class="myMsg" v-if="chatOwnerNickname == users.nickname">
+            <div class="myMsg" v-if="chatOwnerNickname == nickname">
               <div class="msg">
                 <div class="reply-msg-sendername">{{ chatting.userName }}</div>
                 <div class="reply-msg">{{ chatting.userMessage }}</div>
@@ -81,7 +81,7 @@
               </div>
             </div>
             <!-- 내가 채팅방 주인이 아니면 -->
-            <div class="anotherMsg" v-if="chatOwnerNickname != users.nickname">
+            <div class="anotherMsg" v-if="chatOwnerNickname != nickname">
               <span class="anotherName">{{ chatting.senderName }}</span>
               <div class="msg">
                 <div class="reply-msg-sendername">{{ chatting.userName }}</div>

--- a/src/views/ChatWindow.vue
+++ b/src/views/ChatWindow.vue
@@ -62,7 +62,7 @@
                   <!-- 위 div에 마우스 호버되면 아래 span이 보이도록 구상중 -->
                   <span
                     @click="selectMsg(chatting)"
-                    v-if="chatOwnerNickname == nickname"
+                    v-if="chatOwner == users.userId"
                     >답장</span
                   >
                 </div>
@@ -72,7 +72,7 @@
           <!-- 답장 -->
           <div v-if="chatting.replyId != null">
             <!-- 내가 채팅방 주인이면 -->
-            <div class="myMsg" v-if="chatOwnerNickname == nickname">
+            <div class="myMsg" v-if="chatOwner == users.userId">
               <div class="msg">
                 <div class="reply-msg-sendername">{{ chatting.userName }}</div>
                 <div class="reply-msg">{{ chatting.userMessage }}</div>
@@ -81,7 +81,7 @@
               </div>
             </div>
             <!-- 내가 채팅방 주인이 아니면 -->
-            <div class="anotherMsg" v-if="chatOwnerNickname != nickname">
+            <div class="anotherMsg" v-if="chatOwner != users.userId">
               <span class="anotherName">{{ chatting.senderName }}</span>
               <div class="msg">
                 <div class="reply-msg-sendername">{{ chatting.userName }}</div>
@@ -139,15 +139,15 @@ export default {
       chatRoomName: null,
       isReply: false,
       replyChat: {},
-      chatOwnerNickname: null,
+      chatOwner: null,
     };
   },
   async created() {
     try {
       // 비정상적인 요청
-      this.chatOwnerNickname = await this.$store.getters.getChatOwnerNickname;
+      this.chatOwner = await this.$store.getters.getChatOwner;
       this.chatRoomName = await this.$store.getters.getChatRoomName;
-      if (this.chatOwnerNickname == null || this.chatRoomName == null) {
+      if (this.chatOwner == null || this.chatRoomName == null) {
         this.$router.push({ name: "ChatRoom" });
         return;
       }
@@ -169,7 +169,7 @@ export default {
         option
       );
       this.nickname = user.data.nickname;
-      this.$store.commit("setChatOwnerNickname", null);
+      this.$store.commit("setChatOwner", null);
 
       // 웹소켓 연결
       this.connect();

--- a/src/views/MyChatRoom.vue
+++ b/src/views/MyChatRoom.vue
@@ -106,6 +106,7 @@ export default {
     async ToChatting(res) {
       try {
         this.$store.commit("setChatRoomName", res.chatRoomName);
+        this.$store.commit("setChatOwnerNickname", res.nickname);
         const roomId = res.chatRoomId;
         location.href = `/chatWindow/${roomId}`;
       } catch (err) {

--- a/src/views/MyChatRoom.vue
+++ b/src/views/MyChatRoom.vue
@@ -106,7 +106,7 @@ export default {
     async ToChatting(res) {
       try {
         this.$store.commit("setChatRoomName", res.chatRoomName);
-        this.$store.commit("setChatOwnerNickname", res.nickname);
+        this.$store.commit("setChatOwner", res.userId);
         const roomId = res.chatRoomId;
         location.href = `/chatWindow/${roomId}`;
       } catch (err) {

--- a/src/views/MyFollowChat.vue
+++ b/src/views/MyFollowChat.vue
@@ -68,7 +68,7 @@ export default {
       this.user = user.data;
       this.chatList = chat.data;
       for (let chats of this.chatList) {
-        if (chats.nickname != this.user.nickname) {
+        if (chats.userId != this.user.userId) {
           this.followChatList.push(chats);
         }
       }
@@ -81,7 +81,7 @@ export default {
     async ToMyFollwingChat(res) {
       try {
         this.$store.commit("setChatRoomName", res.chatRoomName);
-        this.$store.commit("setChatOwnerNickname", res.nickname);
+        this.$store.commit("setChatOwner", res.userId);
         const roomId = res.chatRoomId;
         location.href = `/chatWindow/${roomId}`;
       } catch (err) {


### PR DESCRIPTION
### 📌 개발 개요
- resolve #101 

> 필터링된(블러처리된) 메세지에 대한 답장 경고

  <br>

### 💻  작업 및 변경 사항
- 작가가 필터링된(블러처리된) 메세지에 대해서 답장을 시도하면 confirm 혹은 alert 창을 통해 경고 알림
  - 욕설이 다른 독자에게 전달되면 불쾌한 기분을 느낄 가능성이 있기 때문
  - 필터링이 완벽한 것이 아니므로 답장을 완전 막아버리는 것은 문제가 있다고 판단해서 경고 알림만
- 새로고침 시 작가 ui가 보이는 문제 수정
- 채팅방 주인 구분 기준을 `nickname` -> `userId`로 변경
  - 기존 `nickname`이 유니크하다는 전달을 받고 작업하였으나, 추후 유니크가 아닌걸로 변경되어 `userId`로 변경
- 답장 기능 디자인
- 채팅창크기를 화면에 맞게 줄이고 내부 스크롤 추가

  <br>

### ✅ Point
- 백엔드가 최신이 아니라면 동작하지 않을 수 있습니다. 확인 전 반드시 백엔드를 최신 브랜치로 업데이트 해주세요
- 마지막이 코앞입니다 파이팅!
  <br>