### PR TITLE
[BUG] 작품 검색 관련 버그

### DIFF
--- a/src/components/layout/MainHeader.vue
+++ b/src/components/layout/MainHeader.vue
@@ -188,15 +188,7 @@ export default {
       this.$router.push("/community");
     },
     toSearch() {
-      this.$router.push({
-        path: "/search",
-        query: {
-          novelId: null,
-          genre: "",
-          author: "",
-          title: this.searchTitle,
-        },
-      });
+      location.href = `/search?title=${this.searchTitle}`;
     },
     toFanclub() {
       this.$router.push("/fanclub");

--- a/src/views/NovelSearchPage.vue
+++ b/src/views/NovelSearchPage.vue
@@ -84,6 +84,7 @@
         </b-row>
       </div>
       <infinite-loading
+        v-if="this.novelId != 0"
         @infinite="infiniteHandler"
         spinner="waveDots"
       ></infinite-loading>
@@ -129,29 +130,14 @@ export default {
         `${process.env.VUE_APP_API_URL}/novel?title=${this.searchTitle}`
       );
       this.novels = res.data;
-      this.novelId = this.novels[this.novels.length - 1].novelId;
+      this.novelId = this.novels[this.novels.length - 1].novelId || 0;
     } catch (err) {
       console.log(err);
     }
   },
   methods: {
     async infiniteHandler($state) {
-      if (!this.novels.length) {
-        // 데이터가 없는 경우 초기 데이터를 가져옵니다.
-        try {
-          const res = await axios.get(
-            `${process.env.VUE_APP_API_URL}/novel?title=${this.searchTitle}`
-          );
-          this.novels = res.data;
-          this.novelId = this.novels[this.novels.length - 1].novelId;
-          $state.loaded();
-        } catch (err) {
-          console.log(err);
-        }
-        return;
-      }
       try {
-        console.log(this.novelId);
         const res = await axios.get(
           `${process.env.VUE_APP_API_URL}/novel?novelId=${this.novelId}&title=${this.searchTitle}&author=${this.author}&genre=${this.selected}`
         );
@@ -178,6 +164,7 @@ export default {
         );
         this.novels = [];
         this.novels = res.data;
+        this.novelId = this.novels[this.novels.length - 1].novelId;
       } catch (err) {
         console.log(err);
       }

--- a/src/views/NovelSearchPage.vue
+++ b/src/views/NovelSearchPage.vue
@@ -32,10 +32,7 @@
         <b-button variant="info" @click="novelRequest()">신청하기</b-button>
       </div>
     </b-col>
-    <div v-if="isEmpty">
-      <h1 class="none-result">검색된 결과가 없습니다.</h1>
-    </div>
-    <div v-else>
+    <div>
       <div class="novel-list-box">
         <b-row>
           <b-col
@@ -103,7 +100,6 @@ export default {
   name: "WorkSearchPage",
   data() {
     return {
-      isEmpty: false,
       title: "",
       novels: [],
       novelId: 0,
@@ -133,11 +129,7 @@ export default {
         `${process.env.VUE_APP_API_URL}/novel?title=${this.searchTitle}`
       );
       this.novels = res.data;
-      if (!this.novels.length) {
-        this.isEmpty = true;
-      } else {
-        this.novelId = this.novels[this.novels.length - 1].novelId;
-      }
+      this.novelId = this.novels[this.novels.length - 1].novelId;
     } catch (err) {
       console.log(err);
     }


### PR DESCRIPTION
### 📌 개발 개요
- resolve #139 

> - 헤더 검색 후 다시 헤더로 검색 시 작동하지 않는 문제
>   - 헤더에서 router.push를 사용해서 페이지 이동이 제대로 되지 않아서 생긴 문제로 추정
> - 헤더로 결과가 없는 검색하면 검색 기능이 작동하지 않는 문제
>   - isEmpty 변수의 관리 문제
> - (결과가 적을 때?) 간헐적으로 결과가 중복 출력되는 문제
>   - 문제 발생 조건이 밝혀지지 않아 명확한 이유는 알 수 없으나, 무한 스크롤과 관련된 것으로 추정

  <br>

### 💻  작업 및 변경 사항
- 헤더 검색 시 페이지 이동을 `router.push`에서 `location.href`로 수정
  - 이전에 `location.href` -> `router.push`로 변경한 적이 있어 이유를 확인했지만, 현재는 수정되어 영향 x
-  헤더 검색 후 결과가 없을 시 `검색된 결과가 없습니다.` 문구 출력 삭제
   - 현재 다른 div로 대체되어 필요 없는 문구이며, 해당 문구와 관련된 `isEmpty` 변수가 버그를 일으키므로 삭제
- 작품 검색 응답이 완료되지 않았을 때, 무한 스크롤이 작동하는 문제 수정
  - _(결과가 적을 때?) 간헐적으로 결과가 중복 출력되는 문제_ 의 원인으로 추정
  - 무한 스크롤이 간헐적으로 비정상 작동하여 데이터 추가 로딩이 안되는 문제 수정
  <br>

### ✅ Point
- _(결과가 적을 때?) 간헐적으로 결과가 중복 출력되는 문제_ 는 너무 간헐적으로, 불규칙적으로 일어나는 문제입니다. 따라서 원인을 파악하기 힘들어 완전히 수정되지 않았을 가능성도 있습니다. 지속적으로 모니터링이 필요합니다
  <br>